### PR TITLE
When recursing dirs, paths with periods in them are skipped.

### DIFF
--- a/bin/_cover.js
+++ b/bin/_cover.js
@@ -86,7 +86,7 @@ var processFile = function(file, outFile){
 	file = path.normalize(file);
 
 	var ext = path.extname(file);
-	if (ext && ext != '.js'){
+	if (fs.statSync(file).isFile() && ext && ext != '.js'){
 		console.warn('ERROR:'.red.inverse + ' ' + file + ' is not a JavaScript file');
 		return;
 	}


### PR DESCRIPTION
Ex: you have a path `lib/foo/bar/sub.folder/...`.

And you use the CLI as so..

```
coverjs -r -o output/ lib/ ...
```

..`sub.folder` will be skipped, along with any other folders that
still need to be checked, causing breakages when (in my case) a
module is required that has not been copied
over during instrumentation.

PS: This was more of a quick fix that I did. I am not sure if there is a better way you would like this done (or refactored to use async method, etc), given the codebase. Appreciate a fix in general, if possible. Really enjoying working with this lib, btw, thanks!
