### PR TITLE
bring coverObject into scope

### DIFF
--- a/lib/Instrument.js
+++ b/lib/Instrument.js
@@ -23,6 +23,7 @@ var Instrument = function(code, name){
 
 	this.headCode = ''+
 		'if (typeof __$coverObject === "undefined"){\n' +
+        '   var __$coverObject = {};\n' +
 		'	if (typeof window !== "undefined") window.__$coverObject = {};\n' +
 		'	else if (typeof global !== "undefined") global.__$coverObject = {};\n' +
 		'	else throw new Error("cannot find the global scope");\n' +


### PR DESCRIPTION
in some systems, putting code into `global` or `window` isn't enough to get a local reference to the object
